### PR TITLE
修复InMemorySecret2FA全局map竞态条件

### DIFF
--- a/database/model/twoFA.go
+++ b/database/model/twoFA.go
@@ -39,6 +39,23 @@ type Secret2FA struct {
 	Image    string `json:"-"`
 }
 
+// cloneSecret2FA returns a deep copy of a Secret2FA.
+// This prevents external code from mutating the store's data
+// through shared slice backing arrays.
+func cloneSecret2FA(v Secret2FA) Secret2FA {
+	out := Secret2FA{Image: v.Image}
+	if v.PassHash != nil {
+		out.PassHash = append([]byte(nil), v.PassHash...)
+	}
+	if v.KeySalt != nil {
+		out.KeySalt = append([]byte(nil), v.KeySalt...)
+	}
+	if v.Secret != nil {
+		out.Secret = append([]byte(nil), v.Secret...)
+	}
+	return out
+}
+
 // Secret2FAStore provides thread-safe access to in-memory 2FA secrets.
 type Secret2FAStore struct {
 	mu   sync.RWMutex
@@ -57,14 +74,14 @@ func (s *Secret2FAStore) Get(key uint64) (Secret2FA, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	v, ok := s.data[key]
-	return v, ok
+	return cloneSecret2FA(v), ok
 }
 
 // Set stores a Secret2FA in the store.
 func (s *Secret2FAStore) Set(key uint64, value Secret2FA) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.data[key] = value
+	s.data[key] = cloneSecret2FA(value)
 }
 
 // Delete removes a Secret2FA from the store.

--- a/database/model/twoFA.go
+++ b/database/model/twoFA.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"sync"
 	"time"
 
 	"gorm.io/gorm"
@@ -38,6 +39,41 @@ type Secret2FA struct {
 	Image    string `json:"-"`
 }
 
+// Secret2FAStore provides thread-safe access to in-memory 2FA secrets.
+type Secret2FAStore struct {
+	mu   sync.RWMutex
+	data map[uint64]Secret2FA
+}
+
+// NewSecret2FAStore creates a new Secret2FAStore.
+func NewSecret2FAStore() *Secret2FAStore {
+	return &Secret2FAStore{
+		data: make(map[uint64]Secret2FA),
+	}
+}
+
+// Get retrieves a Secret2FA from the store.
+func (s *Secret2FAStore) Get(key uint64) (Secret2FA, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.data[key]
+	return v, ok
+}
+
+// Set stores a Secret2FA in the store.
+func (s *Secret2FAStore) Set(key uint64, value Secret2FA) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+}
+
+// Delete removes a Secret2FA from the store.
+func (s *Secret2FAStore) Delete(key uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.data, key)
+}
+
 // InMemorySecret2FA keeps secrets temporarily
 // in memory to set up 2FA.
-var InMemorySecret2FA = make(map[uint64]Secret2FA)
+var InMemorySecret2FA = NewSecret2FAStore()

--- a/handler/login.go
+++ b/handler/login.go
@@ -136,7 +136,7 @@ func Login(payload model.AuthPayload) (httpResponse model.HTTPResponse, httpStat
 				// save the hashed pass (key) in memory for OTP validation step
 				data2FA := model.Secret2FA{}
 				data2FA.PassHash = key
-				model.InMemorySecret2FA[claims.AuthID] = data2FA
+				model.InMemorySecret2FA.Set(claims.AuthID, data2FA)
 			}
 		}
 	}

--- a/handler/twoFA.go
+++ b/handler/twoFA.go
@@ -186,7 +186,7 @@ func Setup2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload) (
 	key := lib.GetArgon2Key([]byte(authPayload.Password), salt, 32)
 
 	// step 6: check if client secret is available in memory
-	data2FA, ok := model.InMemorySecret2FA[claims.AuthID]
+	data2FA, ok := model.InMemorySecret2FA.Get(claims.AuthID)
 	if ok {
 		// delete old QR image if available
 		if lib.FileExist(configSecurity.TwoFA.PathQR + "/" + data2FA.Image) {
@@ -202,7 +202,7 @@ func Setup2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload) (
 	data2FA.KeySalt = salt
 	data2FA.Secret = otpByte
 	data2FA.Image = img
-	model.InMemorySecret2FA[claims.AuthID] = data2FA
+	model.InMemorySecret2FA.Set(claims.AuthID, data2FA)
 
 	// serve the QR to the client
 	httpResponse.Message = configSecurity.TwoFA.PathQR + "/" + img
@@ -242,7 +242,7 @@ func Activate2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload
 	// start 2FA activation procedure
 	//
 	// step 1: check if client secret is available in memory
-	data2FA, ok := model.InMemorySecret2FA[claims.AuthID]
+	data2FA, ok := model.InMemorySecret2FA.Get(claims.AuthID)
 	if !ok {
 		// request user to visit setup endpoint first
 		httpResponse.Message = "request for a new 2-fa secret"
@@ -269,7 +269,7 @@ func Activate2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload
 		if status == configSecurity.TwoFA.Status.Invalid {
 			// save the secret with failed attempt in memory for future validation procedure
 			data2FA.Secret = otpByte
-			model.InMemorySecret2FA[claims.AuthID] = data2FA
+			model.InMemorySecret2FA.Set(claims.AuthID, data2FA)
 
 			httpResponse.Message = "wrong one-time password"
 			httpStatusCode = http.StatusBadRequest
@@ -488,7 +488,7 @@ func Validate2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload
 	// start 2FA validation procedure
 	//
 	// step 1: check if client secret is available in memory
-	data2FA, ok := model.InMemorySecret2FA[claims.AuthID]
+	data2FA, ok := model.InMemorySecret2FA.Get(claims.AuthID)
 	if !ok {
 		httpResponse.Message = "log in again"
 		httpStatusCode = http.StatusBadRequest
@@ -572,7 +572,7 @@ func Validate2FA(claims middleware.MyCustomClaims, authPayload model.AuthPayload
 		if status == configSecurity.TwoFA.Status.Invalid {
 			// save the new secret in memory for future validation procedure
 			data2FA.Secret = otpByte
-			model.InMemorySecret2FA[claims.AuthID] = data2FA
+			model.InMemorySecret2FA.Set(claims.AuthID, data2FA)
 
 			// save in DB to protect from accidental data loss
 			//

--- a/service/common.go
+++ b/service/common.go
@@ -76,7 +76,7 @@ func Validate2FA(encryptedMessage []byte, issuer string, userInput string) ([]by
 
 // DelMem2FA deletes 2FA secrets from memory.
 func DelMem2FA(authID uint64) {
-	delete(model.InMemorySecret2FA, authID)
+	model.InMemorySecret2FA.Delete(authID)
 }
 
 // SendEmail sends a verification/password recovery email if


### PR DESCRIPTION
## 问题

`database/model/twoFA.go` 中的 `InMemorySecret2FA` 是一个全局的 `map[uint64]Secret2FA`，在多个 HTTP handler 中被并发读写，没有任何同步保护（如 `sync.RWMutex`）。

Go 运行时会检测并发 map 访问并抛出不可恢复的 `fatal error`，导致整个服务进程崩溃。

### 受影响的位置

- `handler/login.go:139` — 用户登录时写入 map
- `handler/twoFA.go:205,272,575` — 2FA 设置/激活/验证时写入 map
- `handler/twoFA.go:189,245,491` — 2FA 流程中读取 map
- `service/common.go:79` — 删除 map 条目

### 触发场景

1. 两个已配置 2FA 的用户同时登录 → 并发写入 map
2. 一个用户登录写入 map 的同时另一个用户进行 2FA 验证读取 map

这两种场景都可能导致 `fatal error: concurrent map read and map write` 或 `fatal error: concurrent map writes`。

## 修复

引入 `Secret2FAStore` 结构体，通过 `sync.RWMutex` 保护内部 map，对外暴露 `Get`/`Set`/`Delete` 方法，所有调用方改为使用这些方法而非直接操作 map。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced unprotected in-memory 2FA secret storage with a thread‑safe store to prevent concurrent access issues and accidental secret mutation.
  * Login, 2FA setup/activation/validation, and service delete flows now use the new store interface for consistent get/set/delete handling of temporary OTP secrets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pilinux/gorest/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->